### PR TITLE
Fixed typo on projects page

### DIFF
--- a/src/main/webapp/WEB-INF/projects.jsp
+++ b/src/main/webapp/WEB-INF/projects.jsp
@@ -25,7 +25,7 @@
 	</c:if>    
 </ul>
 
-<h3>Projetcs</h3>
+<h3>Projects</h3>
 <table>
     <thead> 
     	<tr>


### PR DESCRIPTION
The word "Projects" was misspelled on the projects page. 
Resolves #12
